### PR TITLE
moving everything into the same namespace

### DIFF
--- a/cert-manager-cainjector/role-binding.tf
+++ b/cert-manager-cainjector/role-binding.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_role_binding" "role_binding" {
   metadata {
     name      = "${var.name}:leaderelection"
-    namespace = "kube-system"
+    namespace = var.namespace
     labels = merge({
       "app.kubernetes.io/name" = var.name
     }, local.labels)

--- a/cert-manager-cainjector/role.tf
+++ b/cert-manager-cainjector/role.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_role" "role" {
   metadata {
     name      = "${var.name}:leaderelection"
-    namespace = "kube-system"
+    namespace = var.namespace
     labels = merge({
       "app.kubernetes.io/name" = var.name
     }, local.labels)

--- a/cert-manager/role-binding.tf
+++ b/cert-manager/role-binding.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_role_binding" "role_binding" {
   metadata {
     name      = "${var.name}:leaderelection"
-    namespace = "kube-system"
+    namespace = var.namespace
     labels = merge({
       "app.kubernetes.io/name" = var.name
     }, local.labels)

--- a/cert-manager/role.tf
+++ b/cert-manager/role.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_role" "role" {
   metadata {
     name      = "${var.name}:leaderelection"
-    namespace = "kube-system"
+    namespace = var.namespace
     labels = merge({
       "app.kubernetes.io/name" = var.name
     }, local.labels)


### PR DESCRIPTION
per https://cert-manager.io/docs/installation/compatibility/

> Configure cert-manager to use a different namespace for leader election